### PR TITLE
プレイリスト横幅調整

### DIFF
--- a/saikyo-playlist/Views/Player/Index.cshtml
+++ b/saikyo-playlist/Views/Player/Index.cshtml
@@ -48,6 +48,7 @@
         overflow-y: auto;
         border: 1px solid #ced4da;
         border-radius: 5px;
+        width:80%;
     }
 
     .playlist-item-elem {


### PR DESCRIPTION
コンテンツによって横幅が変更されていた表示上の問題を修正
とりあえず`width`を`80%`でスタイル指定

Close #27 